### PR TITLE
create get all users

### DIFF
--- a/controllers/userControllers.js
+++ b/controllers/userControllers.js
@@ -1,17 +1,16 @@
 const { User } = require('../models/userModel');
+const APIFeatures = require('../utils/apiFeatures')
 
 exports.createUser = async (req, res) => {
-    
   try {
     const newUser = await User.create(req.body);
-    const token = await newUser.generateAuthToken()
+    const token = await newUser.generateAuthToken();
 
     res.status(201).json({
       message: 'user successfully created',
       data: { newUser, token }
     });
-  } 
-  catch (err) {
+  } catch (err) {
     res.status(400).json({
       message: 'fail',
       reason: { error: err }
@@ -21,13 +20,19 @@ exports.createUser = async (req, res) => {
 
 exports.getUser = async (req, res) => {
   try {
-    const users = await User.findAllUsers();
+    const features = new APIFeatures(User.find(), req.query)
+      .filter()
+      .sort()
+      .limitFields()
+      .paginate();
+
+    const users = await features.query
+
     res.status(200).json({
       message: 'success',
       data: { users }
     });
-  } 
-  catch (err) {
+  } catch (err) {
     res.status(400).json({
       message: 'fail',
       err

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -23,10 +23,16 @@ const userSchema = mongoose.Schema({
       }
     }
   },
+  joinAt: {
+    type: Date,
+    default: Date.now(),
+    select: false
+  },
   password: {
     type: String,
     required: true,
-    minlength: 5
+    minlength: 5,
+    select: false
   },
   tokens: [
     {

--- a/utils/apiFeatures.js
+++ b/utils/apiFeatures.js
@@ -1,0 +1,53 @@
+class APIFeatures {
+    constructor(query, queryString) {
+      this.query = query;
+      this.queryString = queryString;
+    }
+  
+    filter() {
+      const queryObj = { ...this.queryString };
+      const excludedFields = ['page', 'sort', 'limit', 'fields'];
+      excludedFields.forEach(el => delete queryObj[el]);
+  
+      // Advanced Filtering
+      let queryStr = JSON.stringify(queryObj);
+      queryStr = queryStr.replace(/\b(gte|gt|lte|lt)\b/g, match => `$${match}`);
+  
+      this.query = this.query.find(JSON.parse(queryStr));
+  
+      return this;
+    }
+  
+    sort() {
+      if (this.queryString.sort) {
+        const sortBy = this.queryString.sort.split(',').join(' ');
+        this.query = this.query.sort(sortBy);
+      } else {
+        this.query = this.query.sort('-joinAt');
+      }
+  
+      return this;
+    }
+  
+    limitFields() {
+      if (this.queryString.fields) {
+        const fields = this.queryString.fields.split(',').join(' ');
+        this.query = this.query.select(fields);
+      } else {
+        this.query = this.query.select('-__v');
+      }
+      return this;
+    }
+  
+    paginate() {
+      const page = this.queryString.page * 1 || 1;
+      const limit = this.queryString.limit * 1 || 20;
+      const skip = (page - 1) * limit;
+  
+      this.query = this.query.skip(skip).limit(limit);
+  
+      return this;
+    }
+}
+
+module.exports = APIFeatures


### PR DESCRIPTION
#### What does this PR do?
This PR creates get all users endpoint

A summary of what this PR is about
The PR can fetch all users in the database and can be sorted based on given parameter, it also implement pagination, limits and filter

#### List of task completed
* create get all users endpoint
* implement filter
* implement sort
* add pagination
* implement limits

#### How can this be tested?
Clone this repository 
Run `yarn start` to start the app
Open postman or curl to make a get request to test the endpoint ( http://127.0.0.1:3000/api/v1/users), this should return all the users in the database
Add sort params to sort the users by username by adding the query params like this (http://127.0.0.1:3000/api/v1/users?sort=username) 
You can also query for page and limit

![prayNmeet-get-all-users](https://user-images.githubusercontent.com/49355114/76812307-c26fa800-67f4-11ea-9107-7deac335a847.png)


Add more info if any. eg fixes #.
- [x] remove password from the return value